### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   automerge:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: contains(join(github.event.pull_request.labels.*.name, ','), 'dependencies')
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/lucky845/easy-captcha/security/code-scanning/5](https://github.com/lucky845/easy-captcha/security/code-scanning/5)

To fix the issue, add an explicit `permissions` block at the appropriate scope of the workflow. The recommended approach is to add the `permissions` block at the job level (under `jobs > automerge`), since only this job requires those permissions. The minimal required set for using `actions/checkout` and enabling auto-merge is typically `contents: read` and `pull-requests: write`. Add:

```yaml
permissions:
  contents: read
  pull-requests: write
```

directly under the job definition (after line 9, but before `runs-on`). No changes to steps or other parts are required. No additional imports or method definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
